### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ prompt: {
           },
           validate: function (value) {
             var valid = semver.valid(value);
-            return valid || 'Must be a valid semver, such as 1.2.3-rc1. See http://semver.org/ for more details.';
+            return !!valid || 'Must be a valid semver, such as 1.2.3-rc1. See http://semver.org/ for more details.';
           }
         },
         {


### PR DESCRIPTION
semver.valid(value) does not return true or false. Instead it returns either the version, or null.
As validate excepts boolean true or false this example did not work. The change fixes this.

For semver.valid() source, see: https://github.com/npm/node-semver/blob/master/semver.js#L258-L261